### PR TITLE
jest is now working - now it's only about artemis, jolokia and backend (or mock) server

### DIFF
--- a/artemis-console-extension/artemis-extension/jest.config.ts
+++ b/artemis-console-extension/artemis-extension/jest.config.ts
@@ -13,17 +13,17 @@ const config: JestConfigWithTsJest = {
     "^.+.tsx?$": ["ts-jest", {}],
   },
 
-  //testRegex: "(/__tests__/.*|(\\.|/)simple.(test|spec))\\.[jt]s?$",
+  testRegex: "(/__tests__/.*|(\\.|/).*(test|spec))\\.[jt]s?$",
 
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md)$':
       '<rootDir>/src/__mocks__/fileMock.js',
-   '\\.(css|less)$': '<rootDir>/src/__mocks__/styleMock.js',
+    '\\.(css|less)$': '<rootDir>/src/__mocks__/styleMock.js',
   //  '@hawtiosrc/(.*)': '<rootDir>/src/$1',
     'react-markdown': '<rootDir>/node_modules/react-markdown/react-markdown.min.js',
-    '@patternfly/react-icons': '<rootDir>/src/__mocks__/react-icons.js',
-  //  'keycloak-js': path.resolve(__dirname, './src/__mocks__/keycloak.js'),
-   'monaco-editor': '<rootDir>/src/__mocks__/monacoEditor.js',
+  // '@patternfly/react-icons': '<rootDir>/src/__mocks__/react-icons.js',
+    'keycloak-js': '<rootDir>/src/__mocks__/keycloak.js',
+    'monaco-editor': '<rootDir>/src/__mocks__/monacoEditor.js',
   //  '@monaco-editor/react': path.resolve(__dirname, './src/__mocks__/monacoEditor.js'),
     '@patternfly/react-code-editor': '<rootDir>./src/__mocks__/codeEditorMock.js',
     oauth4webapi: '<rootDir>/src/__mocks__/oauth4webapi.js',

--- a/artemis-console-extension/artemis-extension/src/__mocks__/keycloak.js
+++ b/artemis-console-extension/artemis-extension/src/__mocks__/keycloak.js
@@ -1,0 +1,3 @@
+module.exports = {
+  Keycloak: () => {},
+}

--- a/artemis-console-extension/artemis-extension/src/artemis-extension/artemis/artemis-service.ts
+++ b/artemis-console-extension/artemis-extension/src/artemis-extension/artemis/artemis-service.ts
@@ -153,7 +153,7 @@ class ArtemisService {
 
     private async initBrokerObjectName(): Promise<string> {
         const config = await configManager.getArtemisconfig();
-        var search = await jolokiaService.search(config.jmx.domain + ":broker=*");
+        var search = config.jmx ? await jolokiaService.search(config.jmx.domain + ":broker=*") : [""]
         return search[0] ? search[0] : "";
     }
 

--- a/artemis-console-extension/artemis-extension/src/artemis-extension/artemis/table/ArtemisTable.tsx
+++ b/artemis-console-extension/artemis-extension/src/artemis-extension/artemis/table/ArtemisTable.tsx
@@ -39,7 +39,7 @@ import {
   MenuToggle,
   SelectList
 } from '@patternfly/react-core';
-import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon';
+import { SortAmountDownIcon } from '@patternfly/react-icons';
 import { Thead, Tr, Th, Tbody, Td, IAction, ActionsColumn, Table } from '@patternfly/react-table';
 import { artemisPreferencesService } from '../artemis-preferences-service';
 import {

--- a/artemis-console-extension/artemis-extension/tsconfig.json
+++ b/artemis-console-extension/artemis-extension/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "target": "es5",
     "lib": [
       "dom",
       "dom.iterable",
@@ -17,7 +16,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "module": "NodeNext",
+    "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
@andytaylor I found two things:
* `'@patternfly/react-icons': '<rootDir>/src/__mocks__/react-icons.js'` was causing this `React.createElement: type is invalid` error
* icons have to be included with `import { SortAmountDownIcon } from '@patternfly/react-icons'` instead of `-import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon` - with this former it looks like `package.json` is involved instead of loading the file directly - but that's still a bit of mustery to me

Next week I'll try to write some backend server that returns what's needed for the tests without running external hawtio/artemis/jolokia.